### PR TITLE
Now able to add and see items in deck

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -3,12 +3,10 @@ import 'semantic-ui-css/semantic.css';
 import '@/styles/globals.css';
 import { Input, Button, Menu } from 'semantic-ui-react';
 import Link from 'next/link';
-import { AppProvider } from '@/useHooks/useAppState';
-
 
 export default function App({ Component, pageProps }) {
   return (
-    <AppProvider>
+    <>
       <Menu>
         <Menu.Item as={Link} href='/'>Home</Menu.Item>
         <Menu.Item as={Link} href='/cards'>Card Generator</Menu.Item>
@@ -20,6 +18,6 @@ export default function App({ Component, pageProps }) {
       </Menu>
     
     <Component {...pageProps} />
-    </AppProvider>
+    </>
   ) 
 }

--- a/src/pages/cards.js
+++ b/src/pages/cards.js
@@ -1,54 +1,84 @@
 import React from "react";
-import { Grid, Button, Image, Header, Popup, Loader} from 'semantic-ui-react';
+import { Grid, Button, Image, Header, Popup, Loader } from "semantic-ui-react";
 import CardImage from "@/components/CardImage";
 
-
 export default function Cards() {
-    const [CardImages, setCardImages] = React.useState({loading:true});
+  const [CardImages, setCardImages] = React.useState({ loading: true });
 
-
-    function getCardImages() {
-        fetch(`https://db.ygoprodeck.com/api/v7/randomcard.php`)
-        .then(r=> r.json())
-        .then(r=> {
-            console.log(r);
-            setCardImages(r);
+  function getCardImages() {
+    fetch(`https://db.ygoprodeck.com/api/v7/randomcard.php`)
+      .then((r) => r.json())
+      .then((r) => {
+        console.log(r);
+        setCardImages(r);
+      })
+      .catch((e) =>
+        setCardImages({
+          loading: false,
+          id: 0,
         })
-        .catch(e=> setCardImages({
-            loading: false, id: 0
-        }));
-    }
+      );
+  }
 
-    
-    return(
-        <>
-        
-        <Grid columns='1'>
-            <Grid.Column>
-                <Header as='h1'>Random Card</Header>
-            </Grid.Column>
-            <Loader active={CardImages.loading}/>
+  const addToDeck = () => {
+    const imageDetails = {
+      url: CardImages.card_images[0].image_url,
+    };
+
+    const currentItems = localStorage.getItem("deckItems")
+      ? JSON.parse(localStorage.getItem("deckItems"))
+      : [];
+    const newItems = [...currentItems, imageDetails];
+    localStorage.setItem("deckItems", JSON.stringify(newItems));
+    alert("Item has been added");
+  };
+
+  return (
+    <>
+      <Grid columns="1">
+        <Grid.Column>
+          <Header as="h1">Random Card</Header>
+        </Grid.Column>
+        <Loader active={CardImages.loading} />
         {
-            // if this statment
-            CardImages.id ?
+          // if this statment
+          CardImages.id ? (
             //then do this; true
             <>
-             <Popup
-                trigger={<Image src={CardImages.card_images[0].image_url} alt='Yugioh card'></Image>}
-                on='click'
-                content={<Button color='green' icon='add' content='Add Card' />}
-                />       
-            
+              <Popup
+                trigger={
+                  <Image
+                    src={CardImages.card_images[0].image_url}
+                    alt="Yugioh card"
+                  ></Image>
+                }
+                on="click"
+                content={
+                  <Button
+                    color="green"
+                    icon="add"
+                    content="Add Card"
+                    onClick={addToDeck}
+                  />
+                }
+              />
             </>
+          ) : (
             //else do this; false
-            : <>
-                <h2>Card Not Found</h2>
+            <>
+              <h2>Card Not Found</h2>
             </>
+          )
         }
-            <Grid.Column>
-                <Button content='Summon Card' icon='sync' color='brown' onClick={getCardImages}/> 
-            </Grid.Column>
-        </Grid>
-        </>
-    )
+        <Grid.Column>
+          <Button
+            content="Summon Card"
+            icon="sync"
+            color="brown"
+            onClick={getCardImages}
+          />
+        </Grid.Column>
+      </Grid>
+    </>
+  );
 }

--- a/src/pages/mydeck.js
+++ b/src/pages/mydeck.js
@@ -1,19 +1,28 @@
-import React from "react";
-import useAppState from "@/useHooks/useAppState";
-import { Grid, Button, Header  } from "semantic-ui-react";
-import Head from "next/head";
+import { useState, useEffect } from "react";
+import { Grid, Image } from "semantic-ui-react";
 
-export default function DeckName(){
-    const appState = useAppState();
+export default function DeckName() {
+  const [deckItems, setDeckItems] = useState([]);
 
-    console.log(appState)
-    return(
-        <>
-        <Grid columns={1}>
-        <Grid.Column>
-            <Header as='h1'>{appState.user}'s deck</Header>
-        </Grid.Column>
+  useEffect(() => {
+    const data = localStorage.getItem("deckItems")
+      ? JSON.parse(localStorage.getItem("deckItems"))
+      : [];
+    setDeckItems(data);
+  }, []);
+  return (
+    <div>
+      {deckItems.length ? (
+        <Grid>
+          {deckItems.map((item, index) => (
+            <Grid.Column key={index} computer={4} tablet={8} mobile={16}>
+              <Image src={item.url} />
+            </Grid.Column>
+          ))}
         </Grid>
-        </>
-    )
+      ) : (
+        <h1>No items in the Deck</h1>
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
I modified the pages cards.js and mydeck.js to make sure we can add the items on cards.js and see the result on mydeck.js. The goal was to make sure the items(images) are saved somewhere so we can be able to pull it in on any page. One way to do it was to use a state management solution but since it's not a complex problem, I decided to use the browser's built-in local storage to store the items.

When the user clicks on the "Add Card" button in the cards.js page, the corresponding image is stored in the browser's Local Storage. So when the user goes to the mydeck.js page, we pull in all the images and display. 

I stored each image in an object so that in case of any modification on what is stored on local storage, it will be easy to apply it.